### PR TITLE
Update README + add CLAUDE.md technical guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,152 @@
+# CLAUDE.md
+
+Technical guide for contributors working on PropAI.
+
+## Project Overview
+
+PropAI is a real estate investment intelligence platform. FastAPI backend (Python 3.11+), React 18 frontend (TypeScript), PostgreSQL 16, Redis 7. All orchestrated via Docker Compose.
+
+## Commands
+
+```bash
+# Backend
+cd backend
+pip install -r requirements.txt          # Install deps
+uvicorn main:app --reload                # Run dev server
+pytest tests/ -v                         # Run all 95 tests
+ruff check . && ruff format --check .    # Lint + format check
+
+# Frontend
+cd frontend
+npm install                              # Install deps
+npm run dev                              # Run dev server
+npm run typecheck                        # TypeScript check
+npm run lint                             # Biome lint
+npm run build                            # Production build
+
+# Full stack
+docker-compose up                        # Start everything
+```
+
+## Architecture
+
+### Backend modules
+
+**`engine/financial/`** — Pure Python financial engine. Zero external dependencies. This is the core of PropAI.
+- `models.py` — Pydantic models: `DealInput`, `UnderwritingResult`, `ReturnMetrics`, `SensitivityTable`, `WaterfallResult`
+- `metrics.py` — Cap rate, CoC, DSCR, GRM, debt service, break-even occupancy
+- `dcf.py` — IRR (Newton-Raphson solver), NPV, equity multiple. `Callable` type annotations for sensitivity functions.
+- `proforma.py` — `ProFormaEngine` generates year-by-year pro forma + sensitivity tables
+- `waterfall.py` — `WaterfallEngine` computes LP/GP distributions through promote tiers
+
+**`agents/`** — Claude-powered AI agents. Each is self-contained with its own system prompt, Pydantic output schema, and error handling.
+- All agents use `AsyncAnthropic` client with `tenacity` retry (3 attempts, exponential backoff)
+- All agents handle `json.JSONDecodeError` gracefully with fallback responses
+- Model names are currently hardcoded (e.g., `claude-sonnet-4-6`). These should eventually be env-configurable.
+
+**`data/`** — External market data clients. All use `httpx` async. All degrade gracefully if keys are missing or APIs are down.
+- `market_service.py` orchestrates all sources in parallel via `asyncio.gather`
+- Zillow data is fetched as bulk CSV and cached locally
+
+**`db/`** — PostgreSQL persistence layer (SQLAlchemy 2.0 async).
+- Uses `Uuid` and `JSON` types (cross-platform: works on both PostgreSQL and SQLite for tests)
+- Lazy initialization — app starts without a database; stateless endpoints work; deal endpoints return 503
+- 5 tables: `deals`, `deal_versions` (full DealInput snapshots as JSON), `documents`, `analysis_results`, `portfolios`
+
+**`api/`** — FastAPI routers.
+- Stateless endpoints (`underwriting.py`, `ai.py`, `market.py`, `analysis.py`) — no database needed
+- Persistent endpoints (`deals.py`) — require PostgreSQL. Wraps the same engines with persistence.
+- `deals.py` uses discriminated union for deal creation (3 modes: structured, NL, quick)
+
+**`services/storage.py`** — Document file storage. `LocalStorage` for dev, `StorageBackend` protocol for S3. Path traversal protection via `_safe_path()`. Singleton instance.
+
+### Frontend
+
+React 18 + Vite + Tailwind + React Query. TypeScript throughout. Biome for linting/formatting.
+
+- `src/pages/` — 5 page components (Dashboard, Underwrite, Results, Market, Memo)
+- `src/components/` — Layout, Charts, Reports, Dashboard, Underwriting
+- `src/lib/api.ts` — Axios client with all API methods
+- `src/lib/utils.ts` — Formatting helpers (currency, percent, number)
+
+### Key files to know
+
+| File | What it does | When you'll touch it |
+|---|---|---|
+| `backend/engine/financial/models.py` | All Pydantic models | Adding fields to deals |
+| `backend/api/deals.py` | Deal CRUD (largest file, ~900 lines) | Adding deal features |
+| `backend/db/models.py` | SQLAlchemy models | Schema changes |
+| `backend/main.py` | App entry, auth, rate limiting, CORS | Auth or middleware changes |
+| `backend/config.py` | Centralized settings (Pydantic Settings) | New env vars |
+| `frontend/src/lib/api.ts` | All API client methods | Adding API calls |
+
+## Design Decisions
+
+**Full snapshots for deal versions.** Each `deal_versions` row stores the complete `DealInput` as JSON (~2KB). Not diffs. Any version can be fed directly to `ProFormaEngine` with no reconstruction. Trade-off: slightly more storage for much simpler code.
+
+**Single `analysis_results` table.** All result types (underwriting, memo, screen verdict, DD report) go in one table with a `result_type` discriminator and `result_data` JSON column. Avoids 6 separate tables that all have the same shape.
+
+**Lazy DB initialization.** The database engine is created in the app lifespan, not at module import time. This means `from main import app` works even without asyncpg installed (needed for tests). If DB is unavailable, stateless endpoints work; deal endpoints return 503.
+
+**AI is additive.** The financial engine works with zero API keys. Claude enhances output but doesn't produce the numbers. This means the core product is always available.
+
+## Testing
+
+Tests use `pytest` + `pytest-asyncio`. DB integration tests use SQLite in-memory (no PostgreSQL needed).
+
+```
+tests/
+├── test_financial_engine.py  # 47 tests — metrics, DCF, pro forma, waterfall
+├── test_api.py               # 10 tests — HTTP endpoints via TestClient
+├── test_agents.py            # 7 tests — mocked AI responses
+├── test_deals.py             # 21 tests — DB models + helpers (SQLite)
+├── test_storage.py           # 10 tests — file storage + path traversal
+└── conftest.py               # Shared sample_deal fixture
+```
+
+## Code Style
+
+- **Backend:** Ruff for linting and formatting. Mypy strict on `engine/` only.
+- **Frontend:** Biome for linting and formatting (replaced ESLint). TypeScript strict.
+- Imports: absolute (`from engine.financial.models import DealInput`), not relative.
+- No `print()` in production code — use `logging.getLogger(__name__)`.
+
+## Known Issues
+
+See [GitHub Issues](https://github.com/tmcga/propai/issues). Key ones:
+- #3 — API key auth compare_digest bug
+- #4 — Waterfall LP IRR double-counts equity percentage
+- #14 — No Alembic migration system yet (schema managed via `create_all`)
+
+## Adding a New Agent
+
+1. Create `backend/agents/your_agent.py`
+2. Define output dataclass(es)
+3. Use `AsyncAnthropic` client with `@retry` decorator from tenacity
+4. Handle `json.JSONDecodeError` with a graceful fallback
+5. Add an API endpoint in `backend/api/analysis.py` or `backend/api/deals.py`
+6. Add tests with mocked AI responses in `tests/test_agents.py`
+
+Pattern to follow: `backend/agents/deal_screener.py` (2-pass: math + AI)
+
+## Adding a New API Endpoint
+
+1. Add route to the appropriate router in `backend/api/`
+2. If it needs persistence, add it to `deals.py` and use `Depends(get_db)`
+3. If it's stateless, add it to the relevant router
+4. Use typed Pydantic models for request/response (not `dict`)
+5. Add tests in `tests/test_api.py`
+
+## Prompts Directory
+
+`prompts/` contains 9 Claude system prompts for different RE roles. Most are NOT wired into the API — they're standalone references. Wiring one up is a good contribution:
+
+- `acquisition_analyst.md` — deal screening
+- `underwriting_analyst.md` — deep financial modeling
+- `market_analyst.md` — comp analysis
+- `capital_stack_advisor.md` — debt structuring (213 lines of domain knowledge)
+- `asset_manager.md` — monthly NOI tracking, capex decisions
+- `disposition_analyst.md` — exit strategy, broker selection
+- `development_analyst.md` — ground-up pro formas
+- `due_diligence_analyst.md` — red flag detection
+- `lp_relations.md` — investor communications

--- a/README.md
+++ b/README.md
@@ -1,380 +1,147 @@
 <div align="center">
 
-# 🏢 PropAI
+# PropAI
 
-### Open-source AI copilot for real estate investment
+### The open-source deal intelligence platform for real estate investment
 
-**Underwrite deals · Model developments · Research markets · Generate institutional memos**
+**Screen deals in seconds · Underwrite with AI · Track your pipeline · Generate institutional memos**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.115-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
-[![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)](https://react.dev)
+[![React 18](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)](https://react.dev)
 [![Claude](https://img.shields.io/badge/Powered%20by-Claude-orange)](https://anthropic.com)
-[![Tests](https://img.shields.io/badge/Tests-47%20passing-brightgreen)](#testing)
-
-<br/>
-
-<!-- DEMO GIF — replace with actual screen recording before launch -->
-<img src="docs/assets/demo.gif" alt="PropAI demo" width="860" />
-
-<br/>
-
-### [🚀 Live Demo](https://propai.dev) &nbsp;·&nbsp; [📖 Docs](https://docs.propai.dev) &nbsp;·&nbsp; [💬 Discord](https://discord.gg/propai)
+[![Tests](https://img.shields.io/badge/Tests-95%20passing-brightgreen)](#testing)
+[![CI](https://github.com/tmcga/propai/actions/workflows/ci.yml/badge.svg)](https://github.com/tmcga/propai/actions)
 
 </div>
 
 ---
 
-## What is PropAI?
+PropAI is a self-hostable platform that replaces spreadsheets and $5K/year SaaS tools with an AI-native workflow for real estate investment analysis.
 
-PropAI is a full-stack real estate investment intelligence platform that replaces spreadsheets and $5,000/year SaaS tools with an open-source, AI-native workflow.
-
-Type a deal in plain English. Get back a complete underwriting, market analysis, and a PDF investment memo that looks like it came from a top-tier private equity firm — in under 60 seconds.
+Describe a deal in plain English. Get back a full pro forma, IRR analysis, market intelligence from 4 free data sources, and an institutional-quality investment memo — in under 60 seconds.
 
 ```
 "24-unit apartment in Austin TX at $4.8M. Rents average $2,000/mo.
  70% LTV at 6.75%, 5-year hold, exit at a 5.5 cap."
 ```
 
-↓
-
-✅ Full 5-year pro forma &nbsp; ✅ IRR, NPV, equity multiple &nbsp; ✅ Sensitivity tables
-✅ Market intelligence (Census, FRED, HUD, Zillow) &nbsp; ✅ AI investment memo PDF
+**What you get back:** 5-year pro forma · IRR, NPV, equity multiple · Sensitivity tables · Market intelligence · AI investment memo · Deal screening verdict · Due diligence red flags
 
 ---
 
 ## Features
 
-### 📊 Financial Engine
-- **Pro forma modeling** — year-by-year NOI, debt service, and cash flow projections
-- **Full returns suite** — IRR, NPV, cap rate, cash-on-cash, DSCR, GRM, equity multiple
-- **Sensitivity analysis** — 5×5 IRR and CoC grids (exit cap rate × rent growth)
-- **Equity waterfall** — LP/GP promote structures with multiple IRR hurdles
-- **Loan modeling** — fixed rate, interest-only, and IO-then-amortizing structures
+### Financial Engine
+Pro forma modeling, full returns suite (IRR, NPV, cap rate, cash-on-cash, DSCR, GRM, equity multiple), 5x5 sensitivity tables, LP/GP equity waterfall with promote tiers, and support for fixed, IO, and IO-then-amortizing loan structures. Pure Python — no numpy, no pandas.
 
-### 🗺️ Market Intelligence (all free APIs)
-- **Census Bureau** — demographics, income, housing, vacancy, homeownership
-- **FRED** — mortgage rates, CPI, unemployment, GDP, 10yr Treasury, housing starts
-- **HUD** — Fair Market Rents by bedroom count for every US county
-- **Zillow Research** — home value and rent trends, YoY%, 3/5-year CAGRs
+### Deal Intelligence
+Persistent deals with version history, document ingestion (upload OMs, T-12s, rent rolls — AI extracts the numbers), side-by-side deal comparison, and portfolio management. All backed by PostgreSQL.
 
-### 🤖 AI Agents (powered by Claude)
-- **Natural language deal input** — describe a deal in plain English, get a structured `DealInput`
-- **Investment memo generator** — 9-section institutional memo with AI-written narrative
-- **Assumption validation** — flags aggressive underwriting with plain-English warnings
-- **Market synthesis** — composite market score, tailwinds/headwinds, suggested rent growth
+### Market Intelligence
+Live data from Census Bureau, FRED, HUD, and Zillow — all free APIs. Composite market scoring, tailwinds/headwinds analysis, and suggested rent growth rates. Fetched in parallel with graceful degradation.
 
-### 🏗️ Asset Classes
+### AI Agents
+6 Claude-powered agents: natural language deal parser, investment memo generator, deal screener (go/no-go), due diligence analyst, document parser, and LP communications writer. All with retry logic and error handling.
+
+### Asset Classes
 SFR · Small Multifamily · Multifamily · Office · Retail · Mixed-Use · Industrial · Self-Storage · STR · Ground-Up Development
 
 ---
 
 ## Quick Start
 
-### Prerequisites
-
-| Tool | Version |
-|---|---|
-| Docker + Docker Compose | 24+ |
-| Python | 3.11+ (for local dev) |
-| Node.js | 18+ (for frontend dev) |
-
-### 1. Clone & configure
-
 ```bash
-git clone https://github.com/your-org/propai.git
+git clone https://github.com/tmcga/propai.git
 cd propai
 cp .env.example .env
-```
-
-Edit `.env` and add your API keys — all free:
-
-```bash
-# Required for AI features
-ANTHROPIC_API_KEY=sk-ant-...         # console.anthropic.com (free tier available)
-
-# Optional — enriches market intelligence (all free)
-CENSUS_API_KEY=...                   # api.census.gov/data/key_signup.html
-FRED_API_KEY=...                     # fred.stlouisfed.org/docs/api/api_key.html
-```
-
-> **Note:** PropAI works without any API keys for underwriting and financial modeling.
-> API keys unlock the AI memo generator and live market data.
-
-### 2. Run
-
-```bash
+# Add your ANTHROPIC_API_KEY (free at console.anthropic.com)
 docker-compose up
 ```
 
 | Service | URL |
 |---|---|
 | Frontend | http://localhost:3000 |
-| Backend API | http://localhost:8000 |
 | API Docs | http://localhost:8000/docs |
 
-That's it. The full stack is running.
+> Works without API keys for underwriting and financial modeling. Keys unlock AI agents and live market data.
 
----
-
-## API Reference
-
-The backend is a fully documented FastAPI app. Visit `/docs` for the interactive Swagger UI.
-
-### Underwriting
+For local development without Docker:
 
 ```bash
-# Full underwriting (pro forma + sensitivity tables)
-POST /api/underwrite
+# Backend
+cd backend && python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt && uvicorn main:app --reload
 
-# Quick metrics only (fast screening)
-POST /api/underwrite/quick
-
-# Sample deal
-GET  /api/underwrite/sample/result
-```
-
-### Market Intelligence
-
-```bash
-# Full market report (Census + FRED + HUD + Zillow)
-GET /api/market/metro/{metro}?state_fips=48&county_fips=453
-
-# By ZIP code
-GET /api/market/zip/78701
-
-# Macro snapshot only (no geo required)
-GET /api/market/macro
-
-# Current mortgage rates + 52-week history
-GET /api/market/mortgage-rates
-```
-
-### AI
-
-```bash
-# Full pipeline: plain English → underwriting + memo
-POST /api/ai/analyze
-
-# Parse natural language → structured deal
-POST /api/ai/parse
-
-# Generate memo from structured deal
-POST /api/ai/memo
-
-# Demo memo (no API key needed)
-GET  /api/ai/memo/demo
-```
-
-### Example: underwrite a deal
-
-```python
-import httpx
-
-deal = {
-    "name": "The Austin Arms",
-    "asset_class": "multifamily",
-    "purchase_price": 4_800_000,
-    "units": 24,
-    "market": "Austin, TX",
-    "closing_costs": 0.01,
-    "loan": {
-        "ltv": 0.70,
-        "interest_rate": 0.0675,
-        "amortization_years": 30,
-        "loan_type": "fixed",
-        "origination_fee": 0.01
-    },
-    "operations": {
-        "gross_scheduled_income": 576_000,
-        "vacancy_rate": 0.05,
-        "credit_loss_rate": 0.01,
-        "other_income": 14_400,
-        "property_taxes": 72_000,
-        "insurance": 18_000,
-        "management_fee_pct": 0.05,
-        "maintenance_reserves": 36_000,
-        "capex_reserves": 24_000,
-        "utilities": 12_000,
-        "other_expenses": 8_400,
-        "rent_growth_rate": 0.03,
-        "expense_growth_rate": 0.02
-    },
-    "exit": {
-        "hold_period_years": 5,
-        "exit_cap_rate": 0.055,
-        "selling_costs_pct": 0.03,
-        "discount_rate": 0.08
-    }
-}
-
-result = httpx.post("http://localhost:8000/api/underwrite", json=deal).json()
-
-print(f"Cap Rate:       {result['metrics']['going_in_cap_rate']:.2%}")
-print(f"Levered IRR:    {result['metrics']['levered_irr']:.1%}")
-print(f"Equity Multiple:{result['metrics']['equity_multiple']:.2f}x")
-print(f"DSCR:           {result['metrics']['dscr_yr1']:.2f}x")
-```
-
-### Example: analyze a deal in plain English
-
-```python
-result = httpx.post("http://localhost:8000/api/ai/analyze", json={
-    "text": "24-unit apartment in Austin TX at $4.8M. Rents $2k/mo. 70% LTV at 6.75%, 5yr hold."
-}).json()
-
-# result contains: parsed deal, full underwriting, and complete investment memo
-print(result["memo"]["sections"]["executive_summary"])
+# Frontend
+cd frontend && npm install && npm run dev
 ```
 
 ---
 
-## Architecture
+## API
 
-```
-propai/
-├── backend/                    # FastAPI (Python 3.11)
-│   ├── main.py                 # App entry point
-│   ├── api/
-│   │   ├── underwriting.py     # POST /api/underwrite
-│   │   ├── market.py           # GET  /api/market/*
-│   │   └── ai.py               # POST /api/ai/*
-│   ├── engine/
-│   │   └── financial/
-│   │       ├── models.py       # Pydantic input/output models
-│   │       ├── metrics.py      # Cap rate, CoC, DSCR, GRM, debt service
-│   │       ├── dcf.py          # IRR (Newton-Raphson), NPV, equity multiple
-│   │       ├── proforma.py     # Year-by-year pro forma + sensitivity tables
-│   │       └── waterfall.py    # LP/GP equity waterfall
-│   ├── data/
-│   │   ├── census.py           # US Census Bureau ACS client
-│   │   ├── fred.py             # FRED macroeconomic data client
-│   │   ├── hud.py              # HUD Fair Market Rents client
-│   │   ├── zillow.py           # Zillow Research bulk data client
-│   │   └── market_service.py   # Orchestrates all data sources
-│   ├── agents/
-│   │   ├── memo_agent.py       # Claude-powered investment memo generator
-│   │   └── deal_parser.py      # NL → structured DealInput via tool calling
-│   └── templates/
-│       └── memo.html           # Jinja2 investment memo template
-│
-├── frontend/                   # React 18 + Vite + Tailwind
-│   └── src/
-│       ├── components/
-│       │   ├── Underwriting/   # Deal input forms
-│       │   ├── Dashboard/      # Portfolio view + metrics
-│       │   ├── Reports/        # Memo viewer
-│       │   └── Charts/         # Financial visualizations
-│       └── pages/
-│
-├── notebooks/                  # Jupyter demos
-│   ├── 01_underwriting_demo.ipynb
-│   ├── 02_market_analysis.ipynb
-│   └── 03_ai_memo_generation.ipynb
-│
-├── docker-compose.yml
-└── .env.example
-```
-
-### Design principles
-
-**Financial engine is pure Python, zero dependencies.** The DCF/IRR solver uses Newton-Raphson iteration — no numpy, no pandas, no numpy-financial. This keeps the engine fast, portable, and auditable. Every formula has a docstring explaining the real estate context.
-
-**AI is additive, not load-bearing.** Every feature works without an API key. Claude enhances the output; it doesn't produce the numbers. The financial engine generates the figures; the AI generates the prose.
-
-**Graceful degradation.** Market data fetches run in parallel with `asyncio.gather`. If any single source fails (rate limit, outage, missing key), the others still populate. A partial market report is better than an error.
-
----
-
-## Development
-
-### Backend (Python)
+Full Swagger docs at `/docs` when running.
 
 ```bash
-cd backend
-python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
-uvicorn main:app --reload
+# Stateless (works without database)
+POST /api/underwrite              # Full pro forma + sensitivity
+POST /api/ai/analyze              # Plain English → underwriting + memo
+GET  /api/market/metro/{metro}    # Market report (Census + FRED + HUD + Zillow)
+
+# Deal persistence (requires PostgreSQL)
+POST /api/deals                   # Create deal (structured, NL, or quick)
+POST /api/deals/{id}/underwrite   # Run and save results
+POST /api/deals/{id}/documents    # Upload documents
+POST /api/deals/compare           # Side-by-side comparison
 ```
-
-### Frontend (React)
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-### Testing
-
-```bash
-cd backend
-pytest tests/ -v --cov=engine
-```
-
-```
-47 passed in 0.07s ✓
-```
-
-Tests cover: EGI, NOI, cap rate, GRM, DSCR, CoC, debt service (fixed/IO/IO-then-amortizing), loan balance, IRR, NPV, equity multiple, full pro forma generation, sensitivity tables, waterfall distributions, edge cases (all-cash, 1-year hold).
 
 ---
 
 ## Roadmap
 
-| Phase | Status | What's included |
-|---|---|---|
-| **1 — Financial Engine** | ✅ Complete | Pro forma, DCF, IRR, sensitivity, waterfall |
-| **2 — Market Data** | ✅ Complete | Census, FRED, HUD, Zillow integrations |
-| **3 — AI Agents** | ✅ Complete | Memo generator, NL deal parser |
-| **4 — Frontend** | 🚧 In Progress | React dashboard, deal forms, report viewer |
-| **5 — Development Pro Forma** | 📋 Planned | Ground-up construction, draw schedules |
-| **6 — Comp Analysis** | 📋 Planned | Rent and sales comp grids |
-| **7 — Portfolio Dashboard** | 📋 Planned | Multi-deal tracking, aggregate metrics |
+| Phase | Status |
+|---|---|
+| Financial Engine | Done |
+| Market Data Integrations | Done |
+| AI Agents (6 agents) | Done |
+| Deal Persistence Layer | Done |
+| Frontend | In Progress |
+| Development Pro Forma | Planned |
+| Comp Analysis | Planned |
+| Portfolio Dashboard | Planned |
+
+See [open issues](https://github.com/tmcga/propai/issues) for what needs work.
 
 ---
 
-## Contributing
+## For Developers
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CLAUDE.md](CLAUDE.md) for the full technical guide — architecture, design decisions, how modules connect, and where to start contributing.
 
-**Good first issues:**
-- Add a new asset class to the financial engine
-- Improve sensitivity table granularity
-- Add a new market data source
-- Write additional test cases
-- Improve the investment memo HTML template
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
-**Bigger projects:**
-- React frontend (see `/frontend`)
-- Jupyter notebook demos
-- Additional LLM provider support (OpenAI, Gemini)
-- PDF export via WeasyPrint
-- PostgreSQL deal persistence layer
+**Quick orientation:**
+- `backend/engine/financial/` — the math (pure Python, zero deps, well-tested)
+- `backend/agents/` — AI agents (Claude-powered, each self-contained)
+- `backend/api/` — FastAPI routes (stateless + persistent)
+- `backend/db/` — PostgreSQL persistence (SQLAlchemy 2.0 async)
+- `frontend/src/` — React 18 + Vite + Tailwind
+- `prompts/` — 9 agent system prompts covering the full investment lifecycle
+
+**Testing:** `cd backend && pytest tests/ -v` — 95 tests.
 
 ---
 
 ## Data Sources
 
-All data sources used by PropAI are free:
-
-| Source | Data | Cost |
-|---|---|---|
-| [US Census Bureau](https://api.census.gov) | Demographics, income, housing | Free (key required) |
-| [FRED](https://fred.stlouisfed.org) | Mortgage rates, CPI, unemployment | Free (key required) |
-| [HUD](https://www.huduser.gov/hudapi/public) | Fair Market Rents | Free (no key required) |
-| [Zillow Research](https://www.zillow.com/research/data/) | Home values, rent trends | Free (bulk CSV download) |
-| [Walk Score](https://www.walkscore.com/professional/api.php) | Walkability scores | Free tier (5k/day) |
-
----
-
-## Disclaimer
-
-PropAI is for informational and educational purposes only. Nothing in this software constitutes financial, investment, legal, or tax advice. All projections and models are estimates based on user-provided assumptions. Always conduct independent due diligence and consult qualified professionals before making any investment decision.
+All free: [Census Bureau](https://api.census.gov) · [FRED](https://fred.stlouisfed.org) · [HUD](https://www.huduser.gov/hudapi/public) · [Zillow Research](https://www.zillow.com/research/data/)
 
 ---
 
 ## License
 
-MIT — see [LICENSE](LICENSE). Use it, fork it, build on it.
+[MIT](LICENSE) — use it, fork it, build on it.
+
+**Disclaimer:** PropAI is for informational and educational purposes. It is not financial, investment, legal, or tax advice.


### PR DESCRIPTION
## Summary

- **README** rewritten for open-source audience — focused on the product (what it does, quick start, API, roadmap) with a small "For Developers" section pointing to CLAUDE.md
- **CLAUDE.md** added — full technical guide for contributors: architecture, design decisions, module map, key files, commands, code style, testing, how to add agents/endpoints, prompts directory

## Test plan
- [x] No code changes — docs only